### PR TITLE
switch to codemirror

### DIFF
--- a/lib/core/keys.dart
+++ b/lib/core/keys.dart
@@ -7,8 +7,6 @@ library core.keys;
 import 'dart:async';
 import 'dart:html';
 
-// TODO: test
-
 final _isMac = window.navigator.appVersion.toLowerCase().contains('macintosh');
 
 /**
@@ -63,8 +61,8 @@ String printKeyEvent(KeyboardEvent event) {
 
   // shift ctrl alt
   if (event.shiftKey) buf.write('shift-');
-  if (event.ctrlKey) buf.write(_isMac ? 'macctrl-' : 'ctrl-');
-  if (event.metaKey) buf.write(_isMac ? 'ctrl-' : 'meta-');
+  if (event.ctrlKey) buf.write(isMac() ? 'macctrl-' : 'ctrl-');
+  if (event.metaKey) buf.write(isMac() ? 'ctrl-' : 'meta-');
   if (event.altKey) buf.write('alt-');
 
   if (_codeMap.containsKey(event.keyCode)) {
@@ -75,6 +73,8 @@ String printKeyEvent(KeyboardEvent event) {
 
   return buf.toString();
 }
+
+bool isMac() => _isMac;
 
 final Map _codeMap = {
   KeyCode.ZERO: '0',

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -13,11 +13,9 @@ import 'core/dependencies.dart';
 import 'core/modules.dart';
 import 'editing/editor.dart';
 import 'elements/elements.dart';
-import 'modules/ace_module.dart';
-//import 'modules/codemirror_module.dart';
+//import 'modules/ace_module.dart';
+import 'modules/codemirror_module.dart';
 import 'modules/dartpad_module.dart';
-//import 'modules/mock_analysis.dart';
-//import 'modules/mock_compiler.dart';
 import 'modules/server_analysis.dart';
 import 'modules/server_compiler.dart';
 import 'services/analysis.dart';
@@ -82,8 +80,8 @@ class Playground {
     modules.register(new ServerAnalysisModule());
     //modules.register(new MockCompilerModule());
     modules.register(new ServerCompilerModule());
-    modules.register(new AceModule());
-    //modules.register(new CodeMirrorModule());
+    //modules.register(new AceModule());
+    modules.register(new CodeMirrorModule());
 
     return modules.start();
   }
@@ -166,6 +164,7 @@ class Playground {
     Lines lines = new Lines(source);
 
     analysisService.analyze(source).then((AnalysisResults result) {
+      // TODO: Make sure these show up on the right document.
       _context.dartDocument.setAnnotations(result.issues.map(
           (AnalysisIssue issue) {
         int startLine = lines.getLineForOffset(issue.charStart);

--- a/test/core/keys_test.dart
+++ b/test/core/keys_test.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library dartpad_ui.keys_test;
+
+import 'dart:html';
+
+import 'package:dartpad_ui/core/keys.dart';
+import 'package:unittest/unittest.dart';
+
+void defineTests() {
+  group('keys', () {
+    test('printKeyEvent', () {
+      expect(printKeyEvent(
+          new KeyEvent('foo', altKey: true, keyCode: KeyCode.S)),
+          'alt-s');
+      expect(printKeyEvent(
+          new KeyEvent('foo', shiftKey: true, altKey: true, keyCode: KeyCode.S)),
+          'shift-alt-s');
+      expect(printKeyEvent(
+          new KeyEvent('foo', keyCode: KeyCode.F10)),
+          'f10');
+
+      if (isMac()) {
+        expect(printKeyEvent(
+            new KeyEvent('foo', ctrlKey: true, keyCode: KeyCode.S)),
+            'macctrl-s');
+        expect(printKeyEvent(
+            new KeyEvent('foo', metaKey: true, keyCode: KeyCode.S)),
+            'ctrl-s');
+      } else {
+        expect(printKeyEvent(
+            new KeyEvent('foo', ctrlKey: true, keyCode: KeyCode.S)),
+            'ctrl-s');
+        expect(printKeyEvent(
+            new KeyEvent('foo', metaKey: true, keyCode: KeyCode.S)),
+            'meta-s');
+      }
+    });
+  });
+}

--- a/test/web.dart
+++ b/test/web.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library dartpad.web_test;
+
+import 'package:unittest/html_config.dart';
+
+import 'core/keys_test.dart' as keys_test;
+
+void main() {
+  // Set up the test environment.
+  useHtmlConfiguration();
+
+  // Define the tests.
+  keys_test.defineTests();
+}

--- a/test/web.html
+++ b/test/web.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<!-- Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+     for details. All rights reserved. Use of this source code is governed by a
+     BSD-style license that can be found in the LICENSE file. -->
+
+<html>
+  <head>
+  	<meta charset="utf-8">
+  	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dartpad Web Tests</title>
+  </head>
+
+  <body>
+    <script src="packages/unittest/test_controller.js"></script>
+    <script type="application/dart" src="web.dart"></script>
+    <script src="packages/browser/dart.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
- add some tests for our key handling code
- switch to using codemirror for the editing component - I'm having trouble rendering errors and warnings in-line in ace with any fidelity. @lukechurch 