### PR TITLE
speed up page load; hardcode codemirror

### DIFF
--- a/lib/editing/editor_codemirror.css
+++ b/lib/editing/editor_codemirror.css
@@ -2,8 +2,8 @@
 /* for details. All rights reserved. Use of this source code is governed by a */
 /* BSD-style license that can be found in the LICENSE file. */
 
-@import '../../../packages/codemirror/codemirror.css';
-@import '../../../packages/codemirror/addon/lint/lint.css';
+/*@import '../../../packages/codemirror/codemirror.css';
+@import '../../../packages/codemirror/addon/lint/lint.css';*/
 
 /* CodeMirror tweaks */
 
@@ -17,4 +17,8 @@
   background: inherit !important;
   border-right: none;
   box-shadow: none;
+}
+
+#editpanel {
+  margin-left: -20px;
 }

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -25,7 +25,7 @@ final CodeMirrorFactory codeMirrorFactory = new CodeMirrorFactory._();
 final _gutterId = 'CodeMirror-lint-markers';
 
 class CodeMirrorFactory extends EditorFactory {
-  static final String cssRef = 'packages/dartpad_ui/editing/editor_codemirror.css';
+  //static final String cssRef = 'packages/dartpad_ui/editing/editor_codemirror.css';
   static final String jsRef = 'packages/codemirror/codemirror.js';
 
   CodeMirrorFactory._();
@@ -42,17 +42,17 @@ class CodeMirrorFactory extends EditorFactory {
     List futures = [];
     html.Element head = html.querySelector('html head');
 
-    // <link href="packages/dartpad_ui/editing/editor_codemirror.css"
-    //   rel="stylesheet">
-    html.LinkElement link = new html.LinkElement();
-    link.rel = 'stylesheet';
-    link.href = cssRef;
-    futures.add(_appendNode(head, link));
+//    // <link href="packages/dartpad_ui/editing/editor_codemirror.css"
+//    //   rel="stylesheet">
+//    html.LinkElement link = new html.LinkElement();
+//    link.rel = 'stylesheet';
+//    link.href = cssRef;
+//    futures.add(_appendNode(head, link));
 
-    // <script src="packages/codemirror/codemirror.js"></script>
-    html.ScriptElement script = new html.ScriptElement();
-    script.src = jsRef;
-    futures.add(_appendNode(head, script));
+//    // <script src="packages/codemirror/codemirror.js"></script>
+//    html.ScriptElement script = new html.ScriptElement();
+//    script.src = jsRef;
+//    futures.add(_appendNode(head, script));
 
     return Future.wait(futures);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,15 +11,14 @@ dependencies:
   ace: '>=0.5.10 <0.6.0'
   browser: any
   codemirror: '>=0.1.0 <0.2.0'
-  script_inliner: '>=1.0.0 <2.0.0'
 
 dev_dependencies:
+  dart_to_js_script_rewriter: any
   ghpages_generator: any
   grinder: '>=0.6.0 <0.7.0'
   unittest: any
 
 transformers:
-- script_inliner
-
+- dart_to_js_script_rewriter
 - $dart2js:
     $exclude: ['web/old/playground1.dart', 'web/old/playground2.dart', 'web/packages/csslib/css.dart']

--- a/web/dartpad.css
+++ b/web/dartpad.css
@@ -23,8 +23,7 @@ body {
 header {
   height: 48px;
   line-height: 48px;
-  padding-left: 20px;
-  padding-right: 20px;
+  padding: 0 24px;
   font-size: 150%;
   color: #fff;
   vertical-align: middle;
@@ -34,10 +33,6 @@ header {
   border-width: 4px;
 
   margin-bottom: 16px;
-}
-
-div.header {
-  margin-left: 6px;
 }
 
 section {
@@ -50,7 +45,7 @@ section {
 }
 
 footer {
-  margin: 8px 20px;
+  margin: 8px 24px;
   font-size: 13px;
 }
 

--- a/web/dartpad.html
+++ b/web/dartpad.html
@@ -16,6 +16,12 @@
 
     <link href='http://fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
     <link href='http://fonts.googleapis.com/css?family=Inconsolata:400,700' rel='stylesheet' type='text/css'>
+
+    <!-- codemirror -->
+    <link href="packages/codemirror/css/codemirror.css" rel="stylesheet" media="screen">
+    <link href="packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
+    <link href="packages/codemirror/theme/zenburn.css" rel="stylesheet" media="screen">
+    <link href="packages/dartpad_ui/editing/editor_codemirror.css" rel="stylesheet" media="screen">
   </head>
 
   <body layout vertical>
@@ -71,16 +77,14 @@
       <div flex>
         <a href="https://www.dartlang.org/" target="dartlang">www.dartlang.org</a>
       </div>
-      <!-- TODO: -->
-      <!-- div>Add copyright info</div -->
       <div flex class="right">
         <a href="https://api.dartlang.org/" target="docs">API documentation</a>
       </div>
     </footer>
 
-    <script async type="application/dart" src="dartpad.dart"></script>
-    <script async src="packages/browser/dart.js" data-pub-inline></script>
-    <script>
+    <script src="packages/codemirror/codemirror.js"></script>
+    <script type="application/dart" src="dartpad.dart" async></script>
+    <script async>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)


### PR DESCRIPTION
Fix #2. We're hard-coded to use codemirror (for now), but page loading is now pretty fast. The UI is loaded, rendered, and ready in 300-500ms. Tracking an issue to reduce the size of the codemirror.js file here: #20.