### PR TITLE
put the iframe in a sandbox

### DIFF
--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -57,14 +57,20 @@ class CodeMirrorFactory extends EditorFactory {
   Editor createFromElement(html.Element element, {Map options}) {
     if (options == null) {
       options = {
+        'continueComments': {'continueLineComment': false},
+        'autofocus': true,
+        'autoCloseTags': true,
+        'autoCloseBrackets': true,
         'matchBrackets': true,
         'tabSize': 2,
         'indentUnit': 2,
-        'autofocus': true,
         'cursorHeight': 0.85,
-        'autoCloseBrackets': true,
         'gutters': [_gutterId],
-        'extraKeys': {'Ctrl-Space': 'autocomplete'},
+        'extraKeys': {
+          'Ctrl-Space': 'autocomplete',
+          'Cmd-/': 'toggleComment',
+          'Ctrl-/': 'toggleComment'
+        },
         //'lint': true,
         'theme': 'zenburn' // ambiance, vibrant-ink, monokai, zenburn
       };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   ace: '>=0.5.10 <0.6.0'
   browser: any
-  codemirror: '>=0.1.1 <0.2.0'
+  codemirror: '>=0.1.3 <0.2.0'
 
 dev_dependencies:
   dart_to_js_script_rewriter: any

--- a/web/dartpad.html
+++ b/web/dartpad.html
@@ -67,7 +67,8 @@
           <div flex></div>
         </div>
         <div flex id="outputpanel" layout vertical class="content leftborder">
-          <iframe id="frame" flex four src="frame.html"></iframe>
+          <iframe id="frame" sandbox="allow-scripts" flex four src="frame.html">
+          </iframe>
           <div class="horz_divider"></div>
           <div flex two id="output" class="console"></div>
         </div>


### PR DESCRIPTION
Put the iframe in a sandbox - reduce it's capabilities and make it effectively as if it was loaded from a different domain. `sandbox="allow-scripts"`

Improve the codemirror editing experience - turn on some more codemirror addons.