### PR TITLE
move the app.yaml file

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -14,6 +14,7 @@ final Directory BUILD_DIR = new Directory('build');
 void main(List<String> args) {
   task('init', defaultInit);
   task('build', build, ['init']);
+  task('deploy', deploy, ['build']);
   task('gh-pages', copyGhPages, ['build']);
   task('clean', defaultClean);
 
@@ -32,10 +33,13 @@ void build(GrinderContext context) {
 
   // Reify the symlinks.
   // cp -R -L packages build/web/packages
-  runProcess(context, 'cp', arguments: ['-R', '-L', 'packages', 'build/web/packages']);
+  runProcess(context, 'cp',
+      arguments: ['-R', '-L', 'packages', 'build/web/packages']);
+}
 
-  // TODO: tar it up now? How to distribute?
-
+/// Prepare the app for deployment.
+void deploy(GrinderContext context) {
+  context.log('execute: `appcfg.py update build/web`');
 }
 
 /// Generate a new version of gh-pages.

--- a/web/app.yaml
+++ b/web/app.yaml
@@ -1,5 +1,5 @@
 application: dartpad-dev
-version: 1
+version: 2
 runtime: python27
 api_version: 1
 threadsafe: yes


### PR DESCRIPTION
@lukechurch 

- add a `deploy` step to the grind script
- move the app.yaml file to the web/ folder. This gets copied over to the build/web folder on a build. We then deploy the whole `build/web` folder as the app to app engine