### PR TITLE
some changes for mobile

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -5,16 +5,15 @@
 library dartpad_ui.util;
 
 import 'dart:html';
-import 'dart:math' as math;
 
 /**
  * Return whether we are running on a mobile device.
  */
 bool isMobile() {
-  final int mobileSize = 600;
+  final int mobileSize = 610;
 
   int width = document.documentElement.clientWidth;
   int height = document.documentElement.clientHeight;
 
-  return math.min(width, height) <= mobileSize;
+  return width <= mobileSize || height <= mobileSize;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   ace: '>=0.5.10 <0.6.0'
   browser: any
-  codemirror: '>=0.1.4 <0.2.0'
+  codemirror: '>=0.1.5 <0.2.0'
 
 dev_dependencies:
   dart_to_js_script_rewriter: any

--- a/web/app.yaml
+++ b/web/app.yaml
@@ -9,8 +9,10 @@ handlers:
 - url: /
   static_files: dartpad.html
   upload: dartpad.html
+  secure: always
 
 # access the static resources in the root directory
 - url: /(.*)
   static_files: \1
   upload: (.*)
+  secure: always

--- a/web/dartpad.css
+++ b/web/dartpad.css
@@ -224,6 +224,7 @@ div.toggle {
   line-height: 20px;
   display: block;
   position: relative;
+  min-height: 100px;
 }
 
 .right {

--- a/web/dartpad.html
+++ b/web/dartpad.html
@@ -7,15 +7,18 @@
 <html>
   <head>
   	<meta charset="utf-8">
-  	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+
     <title>Dartpad</title>
 
     <link href="layout.css" rel="stylesheet" media="screen">
     <link href="dartpad.css" rel="stylesheet" media="screen">
     <!-- link href="packages/dartpad_ui/elements/elements.css" rel="stylesheet" media="screen" -->
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Inconsolata:400,700' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Inconsolata:400,700' rel='stylesheet' type='text/css'>
 
     <!-- codemirror -->
     <link href="packages/codemirror/css/codemirror.css" rel="stylesheet" media="screen">
@@ -25,7 +28,7 @@
     <link href="packages/dartpad_ui/editing/editor_codemirror.css" rel="stylesheet" media="screen">
   </head>
 
-  <body layout vertical>
+  <body fullbleed layout vertical>
     <header layout horizontal>
       <div>Dartpad</div>
       <div flex></div>


### PR DESCRIPTION
- bumped the mobile heuristic up a bit
- rev'd the codemirror dep to capture code completion enhancements
- moved to always serve from https
- set a min height on the editor component
- reference the font resources from `//` refs (we can't load http:// content when served from https://)