### PR TITLE
plumb through support for exposing code completion

### DIFF
--- a/lib/editing/editor.dart
+++ b/lib/editing/editor.dart
@@ -15,6 +15,11 @@ abstract class EditorFactory {
   Future init();
 
   Editor createFromElement(html.Element element);
+
+  // TODO: codemirror gives the client more control over where to insert the
+  // completions. With Ace, you can only insert from the requested position
+  // forward.
+  void registerCompleter(String mode, CodeCompleter completer);
 }
 
 abstract class Editor {
@@ -93,15 +98,17 @@ class Position {
   String toString() => '[${line},${char}]';
 }
 
-//abstract class CodeCompleter {
-//  Future<List<Completion>> complete(
-//      Document document, Position position, String prefix);
-//}
-//
-//class Completion {
-//  final String value;
-//
-//  Completion(this.value);
-//
-//  String toString() => value;
-//}
+abstract class CodeCompleter {
+  Future<List<Completion>> complete(Editor editor);
+}
+
+// TODO: positions?
+class Completion {
+  /// The value to insert.
+  final String value;
+
+  /// An optional string that is displayed during auto-completion if specified.
+  final String displayString;
+
+  Completion(this.value, {this.displayString});
+}

--- a/lib/editing/editor_ace.dart
+++ b/lib/editing/editor_ace.dart
@@ -81,20 +81,16 @@ class AceFactory extends EditorFactory {
     editor.commands.removeCommand('gotoline');
     editor.commands.removeCommand('find');
 
-//    // TODO: Make this generic and pluggable.
-//    ace.LanguageTools langTools = ace.require('ace/ext/language_tools');
-//    langTools.addCompleter(new ace.AutoCompleter(_aceCompleter));
-
     return new _AceEditor._(this, editor);
   }
 
-//  Future<List<ace.Completion>> _aceCompleter(ace.Editor editor,
-//      ace.EditSession session, ace.Point position, String prefix) {
-//    // TODO:
-//    print('complete (${session.mode.name}): ${prefix}');
-//
-//    return new Future.value([]);
-//  }
+  void registerCompleter(String mode, CodeCompleter completer) {
+    // TODO:
+//    ace.LanguageTools langTools = ace.require('ace/ext/language_tools');
+//    langTools.addCompleter(new ace.AutoCompleter(_aceCompleter));
+
+
+  }
 }
 
 class _AceEditor extends Editor {

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -94,6 +94,9 @@ class Playground {
     _editpanel.children.first.attributes['flex'] = '';
     editor.resize();
 
+    // TODO: Add a real code completer here.
+    //editorFactory.registerCompleter('dart', new DartCompleter());
+
     keys.bind('ctrl-s', _handleSave);
     keys.bind('ctrl-enter', _handleRun);
 
@@ -290,6 +293,22 @@ class PlaygroundContext extends Context {
         }
       });
     });
+  }
+}
+
+// TODO: For CodeMirror, we get a request each time the user hits a key when the
+// completion popup is open. We need to cache the results when appropriate.
+
+// TODO: We need to cancel completion requests if one is open when we get
+// another.
+
+class DartCompleter extends CodeCompleter {
+  Future<List<Completion>> complete(Editor editor) {
+    return new Future.value([
+      new Completion('one'),
+      new Completion('two'),
+      new Completion('three')
+    ]);
   }
 }
 


### PR DESCRIPTION
Plumb through support for exposing code completion. This is an abstraction over the code completion functionality for ace and code mirror. They don't match up well, so this is a least common denominator interface. We'll probably want to upgrade this abstraction once we have real dart results coming through.