### PR TITLE
finish the implementation of splitters

### DIFF
--- a/lib/dartpad.dart
+++ b/lib/dartpad.dart
@@ -9,6 +9,7 @@ import 'core/dependencies.dart';
 import 'core/event_bus.dart';
 import 'core/keys.dart';
 import 'editing/editor.dart';
+import 'elements/state.dart';
 import 'services/analysis.dart';
 import 'services/compiler.dart';
 import 'services/execution.dart';
@@ -26,3 +27,5 @@ EventBus get eventBus => deps[EventBus];
 Keys get keys => deps[Keys];
 
 EditorFactory get editorFactory => deps[EditorFactory];
+
+State get state => deps[State];

--- a/lib/elements/elements.css
+++ b/lib/elements/elements.css
@@ -3,20 +3,61 @@
 /* BSD-style license that can be found in the LICENSE file. */
 
 .splitter {
-
+ position: relative;
 }
 
 .splitter[horizontal] {
   width: auto;
-  height: 24px;
+  height: 48px;
   cursor: row-resize;
 }
 
 .splitter[vertical] {
-  width: 24px;
+  width: 48px;
   height: auto;
-
-  /*box-shadow: rgba(255, 255, 255, 0.07) 1px 0 0 inset;
-  border-left: 1px solid #121212;*/
   cursor: col-resize;
+}
+
+.inner {
+  position: absolute;
+  pointer-events:none;
+}
+
+.splitter[horizontal] .inner {
+  left: 0;
+  right: 0;
+  height: 1px;
+  margin-top: 23px;
+  box-shadow: rgba(255, 255, 255, 0.07) 0 1px 0;
+  border-bottom: 1px solid #121212;
+}
+
+.splitter[vertical] .inner {
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  margin-left: 23px;
+  box-shadow: rgba(255, 255, 255, 0.07) 1px 0 0 inset;
+  border-left: 1px solid #121212;
+}
+
+.splash {
+  background: #333;
+  pointer-events:none;
+
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+
+  z-index: 1000;
+  opacity: 1;
+
+  transition: opacity .1s linear;
+  -webkit-transition: opacity .1s linear;
+}
+
+.splash.hide {
+  opacity: 0;
 }

--- a/lib/elements/elements.css
+++ b/lib/elements/elements.css
@@ -2,8 +2,10 @@
 /* for details. All rights reserved. Use of this source code is governed by a */
 /* BSD-style license that can be found in the LICENSE file. */
 
+/* Splitter css. */
+
 .splitter {
- position: relative;
+  position: relative;
 }
 
 .splitter[horizontal] {
@@ -40,6 +42,8 @@
   box-shadow: rgba(255, 255, 255, 0.07) 1px 0 0 inset;
   border-left: 1px solid #121212;
 }
+
+/* Splash css. */
 
 .splash {
   background: #333;

--- a/lib/elements/state.dart
+++ b/lib/elements/state.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/**
+ * A library for storing non-semantic user state, like UI component positions.
+ * This information is differentiated from user configurable settings.
+ */
+library dartpad_ui.state;
+
+import 'dart:convert' show JSON;
+import 'dart:html';
+
+abstract class State {
+  dynamic operator[](String key);
+  void operator[]=(String key, dynamic value);
+}
+
+class HtmlState implements State {
+  final String id;
+  Map<String, dynamic> _values = {};
+
+  HtmlState(this.id) {
+    if (window.localStorage.containsKey(id)) {
+      _values = JSON.decode(window.localStorage[id]);
+    }
+  }
+
+  dynamic operator[](String key) => _values[key];
+
+  void operator[]=(String key, dynamic value) {
+    _values[key] = value;
+    window.localStorage[id] = JSON.encode(_values);
+  }
+}

--- a/lib/modules/dartpad_module.dart
+++ b/lib/modules/dartpad_module.dart
@@ -10,6 +10,7 @@ import '../core/dependencies.dart';
 import '../core/event_bus.dart';
 import '../core/keys.dart';
 import '../core/modules.dart';
+import '../elements/state.dart';
 
 class DartpadModule extends Module {
   Future init() {
@@ -19,6 +20,7 @@ class DartpadModule extends Module {
 
     deps[EventBus] = new EventBus();
     deps[Keys] = new Keys();
+    deps[State] = new HtmlState('dartpad');
 
     return new Future.value();
   }

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -28,8 +28,6 @@ import 'src/util.dart';
 // TODO: we need blinkers when something happens. console is appended to,
 // css is updated, result area dom is modified.
 
-// TODO: we need a component for the output area
-
 Playground get playground => _playground;
 
 Playground _playground;
@@ -64,8 +62,6 @@ class Playground {
       if (!isMobile()) _context.focus();
     });
 
-    /*DSplitter splitter = new DSplitter(querySelector('#vert_split'));*/
-
     _initModules().then((_) {
       _initPlayground();
     });
@@ -84,6 +80,23 @@ class Playground {
   }
 
   void _initPlayground() {
+    // TODO: Set up some automatic value bindings.
+    DSplitter editorSplitter = new DSplitter(querySelector('#editor_split'));
+    editorSplitter.onPositionChanged.listen((pos) {
+      state['editor_split'] = pos;
+    });
+    if (state['editor_split'] != null) {
+     editorSplitter.position = state['editor_split'];
+    }
+
+    DSplitter outputSplitter = new DSplitter(querySelector('#output_split'));
+    outputSplitter.onPositionChanged.listen((pos) {
+      state['output_split'] = pos;
+    });
+    if (state['output_split'] != null) {
+      outputSplitter.position = state['output_split'];
+    }
+
     // Set up iframe.
     deps[ExecutionService] = new ExecutionServiceIFrame(_frame);
     executionService.onStdout.listen(_showOuput);
@@ -114,6 +127,9 @@ class Playground {
     });
 
     _context.onDartReconcile.listen((_) => _performAnalysis());
+
+    DSplash splash = new DSplash(querySelector('div.splash'));
+    splash.hide();
 
     // TODO: This will need to be re-worked.
     // Run the current contents.

--- a/test/web.dart
+++ b/test/web.dart
@@ -5,7 +5,6 @@
 library dartpad.web_test;
 
 import 'package:unittest/html_config.dart';
-import 'package:unittest/unittest.dart';
 
 import 'core/dependencies_test.dart' as dependencies_test;
 import 'core/event_bus_test.dart' as event_bus_test;
@@ -15,7 +14,7 @@ import 'services/common_test.dart' as common_test;
 void main() {
   // Set up the test environment.
   // TODO: Use LoggingHtmlConfiguration when available.
-  unittestConfiguration = new HtmlConfiguration(false);
+  useHtmlConfiguration(false);
 
   // Define the tests.
   dependencies_test.defineTests();

--- a/web/dartpad.css
+++ b/web/dartpad.css
@@ -32,12 +32,13 @@ header {
   border-bottom: 1px solid #121212;
   border-width: 4px;
 
-  margin-bottom: 16px;
+  margin-bottom: 24px;
 }
 
 section {
-  margin: 0;
-  padding-bottom: 8px;
+  margin: 0 24px;
+  padding-bottom: 24px;
+  position: relative;
 
   box-shadow: rgba(255, 255, 255, 0.07) 0 1px 0;
   border-bottom: 1px solid #121212;
@@ -50,22 +51,8 @@ footer {
 }
 
 .view {
-  margin: 0 24px;
+  margin: 0 0;
   min-width: 200px;
-}
-
-.noleft {
-  margin-left: 0;
-}
-
-.leftmargin {
-  margin-left: 16px;
-}
-
-.leftborder {
-  padding-left: 16px;
-  box-shadow: rgba(255, 255, 255, 0.07) 1px 0 0 inset;
-  border-left: 1px solid #121212;
 }
 
 .content {
@@ -160,6 +147,10 @@ button[disabled] {
   font-size: 14px;
 }
 
+#frame {
+  min-height: 100px;
+}
+
 iframe {
   border: none;
 }
@@ -209,7 +200,7 @@ div.toggle {
   font-family: 'Inconsolata', monospace;
   font-size: 12pt;
   line-height: 20px;
-  min-height: 100px;
+  min-height: 50px;
   overflow-y: auto;
   white-space: pre-wrap;
 }

--- a/web/dartpad.html
+++ b/web/dartpad.html
@@ -6,16 +6,16 @@
 
 <html>
   <head>
-  	<meta charset="utf-8">
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <title>Dartpad</title>
+    <title>Dartpad [alpha]</title>
 
     <link href="layout.css" rel="stylesheet" media="screen">
     <link href="dartpad.css" rel="stylesheet" media="screen">
-    <!-- link href="packages/dartpad_ui/elements/elements.css" rel="stylesheet" media="screen" -->
+    <link href="packages/dartpad_ui/elements/elements.css" rel="stylesheet" media="screen">
 
     <link href='//fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
     <link href='//fonts.googleapis.com/css?family=Inconsolata:400,700' rel='stylesheet' type='text/css'>
@@ -30,18 +30,13 @@
 
   <body fullbleed layout vertical>
     <header layout horizontal>
-      <div>Dartpad</div>
+      <div>Dartpad [alpha]</div>
       <div flex></div>
-      <!-- div>
-        <a small href="https://gist.github.com/devoncarew/6893556">gist:6893556</a>
-      </div>
-        &nbsp;&nbsp;
-      <div>
-        <button disabled>Save</button>
-      </div -->
     </header>
 
     <section flex layout horizontal>
+      <div class="splash"></div>
+
       <div class="view" flex three layout vertical>
         <div class="header" layout horizontal>
           <li><a id="darttab" selected class="arrow_box"><span>Dart</span></a></li>
@@ -63,27 +58,33 @@
         </div>
       </div>
 
-      <!-- div class="splitter" vertical id="vert_split"></div -->
+      <div class="splitter" vertical id="editor_split">
+        <div class="inner"></div>
+      </div>
 
-      <div class="view noleft" flex two layout vertical>
-        <div class="header leftmargin" layout horizontal>
-          <div flex></div>
+      <div class="view" flex two layout vertical>
+        <iframe id="frame" sandbox="allow-scripts" flex four src="frame.html">
+        </iframe>
+        <div class="splitter" horizontal id="output_split">
+          <div class="inner"></div>
         </div>
-        <div flex id="outputpanel" layout vertical class="content leftborder">
-          <iframe id="frame" sandbox="allow-scripts" flex four src="frame.html">
-          </iframe>
-          <div class="horz_divider"></div>
-          <div flex two id="output" class="console"></div>
+        <div flex two id="output" class="console"></div>
         </div>
       </div>
     </section>
 
     <footer layout horizontal>
-      <div flex>
+      <div>
         <a href="https://www.dartlang.org/" target="dartlang">www.dartlang.org</a>
       </div>
-      <div flex class="right">
+      <div flex></div>
+      <div>
         <a href="https://api.dartlang.org/" target="docs">API documentation</a>
+      </div>
+      <div flex></div>
+      <div>
+        <a href="https://github.com/dart-lang/dartpad_ui/issues"
+          target="github_issues">Send feedback</a>
       </div>
     </footer>
 


### PR DESCRIPTION
Fix #1.

- finish the implementation of a splitter component
- add `alpha` to the page title
- add a link for user feedback
- refresh the UI to use the splitter and adjust margins
- add a splash screen, so the splitter adjust when the app first launches (resetting to the last user position) doesn't jump. The splash screen is removed once the UI is complete, and hides w/ a 100ms fade out
