### PR TITLE
zenburn theme overrides for hints

### DIFF
--- a/lib/editing/editor_codemirror.css
+++ b/lib/editing/editor_codemirror.css
@@ -48,20 +48,20 @@
 /* Zenburn theme overrides for code completion. */
 
 .CodeMirror-hints {
-	border: 1px solid #cc9393;
-	font-size: 100%;
-	background: grey;
+  border: 1px solid #cc9393;
+  font-size: 100%;
+  background: grey;
 }
 
 .CodeMirror-hint {
-	background: #3f3f3f;
-	color: #dcdccc;
-	border-radius: 0px;
+  background: #3f3f3f;
+  color: #dcdccc;
+  border-radius: 0px;
 }
 
 li.CodeMirror-hint-active {
-	background: #545454;
-	color: #f0dfaf;
+  background: #545454;
+  color: #f0dfaf;
 }
 
 .CodeMirror-hints::-webkit-scrollbar-track {

--- a/lib/editing/editor_codemirror.css
+++ b/lib/editing/editor_codemirror.css
@@ -44,3 +44,36 @@
 .squiggle-info {
   border-bottom: 2px solid #7EA7D8;
 }
+
+/* Zenburn theme overrides for code completion. */
+
+.CodeMirror-hints {
+	border: 1px solid #cc9393;
+	font-size: 100%;
+	background: grey;
+}
+
+.CodeMirror-hint {
+	background: #3f3f3f;
+	color: #dcdccc;
+	border-radius: 0px;
+}
+
+li.CodeMirror-hint-active {
+	background: #545454;
+	color: #f0dfaf;
+}
+
+.CodeMirror-hints::-webkit-scrollbar-track {
+  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
+  background-color: #545454;
+}
+
+.CodeMirror-hints::-webkit-scrollbar {
+  width: 6px;
+  background-color: #545454;
+}
+
+.CodeMirror-hints::-webkit-scrollbar-thumb {
+  background-color: #000000;
+}


### PR DESCRIPTION
@stevemessick, ptal, css to theme codemirror's hints popup.

![screen shot 2015-01-30 at 12 11 40 pm](https://cloud.githubusercontent.com/assets/1269969/5982576/418759a8-a879-11e4-9d39-65c4aa719ebe.png)
