### PR TITLE
font size tweaks; button display

### DIFF
--- a/lib/elements/elements.css
+++ b/lib/elements/elements.css
@@ -120,3 +120,20 @@
   color: #000;
   background-color: rgba(126, 167, 216, 0.8);
 }
+
+.shell {
+  /*bottom: 0;
+  position: absolute;
+  left: 40px;
+  right: 40px;*/
+
+  /*min-height: 70px;*/
+
+  /*z-index: 10;*/
+
+  border: 1px solid #272727;
+  border-radius: 2px;
+  background-color: #3a3a3a;
+  padding: 8px 16px;
+  box-shadow: 3px 3px 4px 0px rgba(15, 14, 14, 0.7);
+}

--- a/web/dartpad.css
+++ b/web/dartpad.css
@@ -35,6 +35,10 @@ header {
   margin-bottom: 24px;
 }
 
+.header-title {
+  text-shadow: rgba(0,0,0,0.75) 0px 1px;
+}
+
 section {
   margin: 0 24px;
   padding-bottom: 24px;
@@ -48,6 +52,7 @@ section {
 footer {
   margin: 8px 24px;
   font-size: 13px;
+  text-shadow: rgba(0,0,0,0.75) 0px 1px;
 }
 
 .view {
@@ -104,25 +109,26 @@ a[selected]:hover {
 .header {
   height: 24px;
   line-height: 24px;
-  font-size: 15px;
+  font-size: 12pt;
 }
 
 button {
   outline: none;
   min-width: 48px;
-  background: rgba(255, 255, 255, 0.06);
   color: #aaa;
   fill: #aaa;
-  border: 1px solid rgba(0, 0, 0, 0.5);
+  border: 1px solid #222;
   border-radius: 2px;
   font-family: 'Roboto', sans-serif;
-  font-size: 15px;
+  font-size: 12pt;
   line-height: 18px;
   height: 24px;
   cursor: pointer;
   padding: 2px 6px;
   transition: 100ms;
   min-width: 75px;
+  background-color: #444;
+  background-image: linear-gradient(to bottom, #444, #333);
 }
 
 button:hover {

--- a/web/dartpad.html
+++ b/web/dartpad.html
@@ -37,7 +37,7 @@
 
   <body fullbleed layout vertical>
     <header layout horizontal>
-      <div>Dartpad <span class="alpha">alpha</span></div>
+      <div class="header-title">Dartpad <span class="alpha">alpha</span></div>
       <div flex></div>
     </header>
 


### PR DESCRIPTION
- normalize some font sizes; we have fewer on the screen now, and they work better on mobile devices
- add a gradient to the run button; it has more visual interest now
- add a slight shadow to the header title

![screen shot 2015-02-01 at 10 26 04 am](https://cloud.githubusercontent.com/assets/1269969/5993210/4da2486c-a9fd-11e4-81a1-16c34e3c10a7.png)
![screen shot 2015-02-01 at 10 26 16 am](https://cloud.githubusercontent.com/assets/1269969/5993211/4dcd5bb0-a9fd-11e4-9d5b-b6630c64f06e.png)
