### PR TITLE
add a title to gists

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -97,6 +97,9 @@ class Playground {
       }
     }
 
+    _setGistDescription(null);
+    _setGistId(null, null);
+
     // TODO: What should the workflow be for hitting '/'? Load the last sample
     // edited here?
     context.dartSource = sample.dartCode;
@@ -120,12 +123,15 @@ class Playground {
   }
 
   void _showGist(String gistId) {
-    // Load the gist.
+    // Load the gist using the github gist API:
+    // https://developer.github.com/v3/gists/#get-a-single-gist.
     HttpRequest.getString('https://api.github.com/gists/${gistId}').then((data) {
       Map m = JSON.decode(data);
 
       String description = m['description'];
       _logger.info('Loaded gist ${gistId} (${description})');
+      _setGistDescription(description);
+      _setGistId(m['id'], m['html_url']);
 
       Map files = m['files'];
 
@@ -357,6 +363,26 @@ class Playground {
     span.text = message;
     _outputpanel.children.add(span);
     span.scrollIntoView(ScrollAlignment.BOTTOM);
+  }
+
+  void _setGistDescription(String description) {
+    Element e = querySelector('header .header-gist-name');
+    e.text = description == null ? '' : description;
+  }
+
+  void _setGistId(String title, String url) {
+    Element e = querySelector('header .header-gist-id');
+
+    if (title == null || url == null) {
+      e.text = '';
+    } else {
+      e.children.clear();
+
+      AnchorElement a = new AnchorElement(href: url);
+      a.text = title;
+      a.target = 'gist';
+      e.children.add(a);
+    }
   }
 }
 

--- a/web/dartpad.css
+++ b/web/dartpad.css
@@ -24,7 +24,6 @@ header {
   height: 48px;
   line-height: 48px;
   padding: 0 24px;
-  font-size: 150%;
   color: #fff;
   vertical-align: middle;
 
@@ -33,10 +32,31 @@ header {
   border-width: 4px;
 
   margin-bottom: 24px;
+  text-shadow: rgba(0,0,0,0.75) 0px 1px;
 }
 
 .header-title {
-  text-shadow: rgba(0,0,0,0.75) 0px 1px;
+  text-overflow: ellipsis;
+  font-size: 16pt;
+}
+
+.header-title .minor {
+  color: #888;
+}
+
+.header-gist-name {
+  text-overflow: ellipsis;
+  margin-left: 1em;
+  margin-right: 1em;
+  color: #ccc;
+  font-size: 14pt;
+}
+
+.header-gist-id {
+  text-overflow: ellipsis;
+  color: #ccc;
+  font-size: 10pt;
+  text-transform: uppercase;
 }
 
 section {
@@ -73,10 +93,12 @@ a {
 a,
 a:visited {
   color: #ccc;
+  fill: #ccc;
 }
 
 a:hover {
   color: #fff;
+  fill: #fff;
 }
 
 a[selected] {

--- a/web/dartpad.html
+++ b/web/dartpad.html
@@ -11,7 +11,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <title>Dartpad (alpha)</title>
+    <title>Dart Codepad (alpha)</title>
 
     <link href="layout.css" rel="stylesheet" media="screen">
     <link href="dartpad.css" rel="stylesheet" media="screen">
@@ -28,17 +28,15 @@
     <link href="packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
     <link href="packages/codemirror/theme/zenburn.css" rel="stylesheet" media="screen">
     <link href="packages/dartpad_ui/editing/editor_codemirror.css" rel="stylesheet" media="screen">
-    <style>
-      .alpha {
-        color: #888;
-      }
-    </style>
   </head>
 
   <body fullbleed layout vertical>
     <header layout horizontal>
-      <div class="header-title">Dartpad <span class="alpha">alpha</span></div>
+      <div class="header-title">Dart Codepad <span class="minor">(alpha!)</span></div>
       <div flex></div>
+      <div class="header-gist-name"></div>
+      <div flex></div>
+      <div class="header-gist-id"></div>
     </header>
 
     <section flex layout horizontal>
@@ -83,16 +81,19 @@
 
     <footer layout horizontal>
       <div>
-        <a href="https://www.dartlang.org/" target="dartlang">www.dartlang.org</a>
-      </div>
-      <div flex></div>
-      <div>
         <a href="https://api.dartlang.org/" target="docs">API documentation</a>
       </div>
       <div flex></div>
       <div>
         <a href="https://github.com/dart-lang/dartpad_ui/issues"
-          target="github_issues">Send feedback</a>
+          target="github_issues">
+            Send feedback
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                style="margin-bottom: -4px"
+                viewBox="0 0 24 24">
+              <path d="M21.99 4c0-1.1-.89-2-1.99-2h-16c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4-.01-18zm-3.99 10h-12v-2h12v2zm0-3h-12v-2h12v2zm0-3h-12v-2h12v2z"/>
+            </svg>
+          </a>
       </div>
     </footer>
 


### PR DESCRIPTION
- add a title to the loaded gists
- tweak the ui of the feedback link
- remove the dartlang link. Having three links in the header and the footer meant that the middle two links were mostly not vertically aligned - it was a little dissonant.

![screen shot 2015-02-03 at 6 46 06 am](https://cloud.githubusercontent.com/assets/1269969/6022316/cff2bc92-ab70-11e4-889d-bca82e54ce5d.png)

TBR, @lukechurch 